### PR TITLE
http connection errors

### DIFF
--- a/packages/bash/lib/releaseSetup.sh
+++ b/packages/bash/lib/releaseSetup.sh
@@ -7,15 +7,19 @@ set -euxo pipefail
 
 gitBranch=$(m git branch)
 
+# TODO: Create command to verify that we are allowed to create a release
+#  this involves adding a field to the releaseFrom object in m.json
 # Only release from the master branch
-[ "$gitBranch" == "master" ] \
-  || m message error 'releases can be done only from the master branch'
+# [ "$gitBranch" == "master" ] \
+#   || m message error 'releases can be done only from the master branch'
 
 # Gather info
 git fetch --tags
 currentVersion=$(git describe --tags || echo '0.0.0')
 newVersion=$(m ci bump_version "$currentVersion")
 
+# TODO: The release object may not specify the `release` branch. It may be
+#  something else.
 # Swith to release branch
 git checkout -b release \
   || m message error "Unable to switch to release branch"

--- a/packages/python/m/core/http.py
+++ b/packages/python/m/core/http.py
@@ -38,15 +38,15 @@ def fetch(
             f'{protocol} request failure',
             cause=ex,
             data=dict(url=url))
-    res = connection.getresponse()
-    code = res.status
     try:
+        res = connection.getresponse()
+        code = res.status
         res_body = res.read()
         if 200 <= code < 300:
             return Good(res_body)
         return issue(
             f'{protocol} request failure ({code})',
-            data=dict(url=url, body=body, code=code, res_body=res_body)
+            data=dict(url=url, body=body, code=code, res_body=str(res_body))
         )
     except Exception as ex:
         return issue(


### PR DESCRIPTION
- Catches errors that may be throws when fetching a response.
- Allow releaseSetup.sh to be run from any branch. This is necessary since the git flow model requires us to create a release from the develop branch so that it can be merged into master. 