### PR TITLE
Allow ci lint to specify the max number of lines per error

### DIFF
--- a/packages/python/m/ci/linter/__init__.py
+++ b/packages/python/m/ci/linter/__init__.py
@@ -5,7 +5,7 @@ from .pycodestyle import read_payload as read_pycodestyle_payload
 from .pylint import read_payload as read_pylint_payload
 
 
-def get_linter(key: str) -> OneOf[Issue, Linter]:
+def get_linter(key: str, max_lines: int) -> OneOf[Issue, Linter]:
     """Find an available linter based on the key provided."""
     mapping = dict(
         eslint=read_eslint_payload,
@@ -14,4 +14,4 @@ def get_linter(key: str) -> OneOf[Issue, Linter]:
     )
     if key not in mapping:
         return issue(f'{key} is not a supported linter')
-    return Good(linter(key, mapping[key]))
+    return Good(linter(key, max_lines, mapping[key]))

--- a/packages/python/m/ci/release_setup.py
+++ b/packages/python/m/ci/release_setup.py
@@ -110,10 +110,10 @@ def release_setup(
     m_dir: str,
     new_ver: str,
     changelog: str = 'CHANGELOG.md',
-) -> OneOf[Issue, int]:
+) -> OneOf[Issue, None]:
     """Modify all the necessary files to create a release."""
     return one_of(lambda: [
-        0
+        None
         for config in read_config(m_dir)
         for first_sha in get_first_commit_sha()
         for _ in update_version(m_dir, new_ver)

--- a/packages/python/m/cli/commands/ci/lint.py
+++ b/packages/python/m/cli/commands/ci/lint.py
@@ -75,6 +75,13 @@ def add_parser(sub_parser, raw):
         help='config data: @filename (file), string'
     )
     add(
+        'm',
+        '--max-lines',
+        default=5,
+        type=int,
+        help='maximum number of lines to print per error'
+    )
+    add(
         '--traceback',
         action='store_true',
         help='display the exception traceback if available'
@@ -89,7 +96,7 @@ def run(arg):
 
     result = one_of(lambda: [
         res
-        for linter in get_linter(arg.tool)
+        for linter in get_linter(arg.tool, arg.max_lines)
         for res in linter(arg.payload, arg.config, sys.stdout)
     ])
     if result.is_bad:

--- a/packages/python/m/cli/commands/ci/lint.py
+++ b/packages/python/m/cli/commands/ci/lint.py
@@ -75,7 +75,7 @@ def add_parser(sub_parser, raw):
         help='config data: @filename (file), string'
     )
     add(
-        'm',
+        '-m',
         '--max-lines',
         default=5,
         type=int,

--- a/packages/python/m/cli/commands/ci/release_setup.py
+++ b/packages/python/m/cli/commands/ci/release_setup.py
@@ -1,4 +1,4 @@
-from ...utils import call_main
+from ...utils import run_main
 
 
 def add_parser(sub_parser, raw):
@@ -20,4 +20,8 @@ def add_parser(sub_parser, raw):
 def run(arg):
     # pylint: disable=import-outside-toplevel
     from ....ci.release_setup import release_setup
-    return call_main(release_setup, [arg.m_dir, arg.new_ver, arg.changelog])
+    return run_main(lambda: release_setup(
+        arg.m_dir,
+        arg.new_ver,
+        arg.changelog
+    ))

--- a/packages/python/tests/ci/lint.py
+++ b/packages/python/tests/ci/lint.py
@@ -9,9 +9,9 @@ from m.ci.linter.status import ProjectStatus, ExitCode, linter
 from ..util import FpTestCase, read_fixture
 
 
-eslint = linter('eslint', read_eslint_payload)
-pycodestyle = linter('pycodestyle', read_pycodestyle_payload)
-pylint = linter('pylint', read_pylint_payload)
+eslint = linter('eslint', 5, read_eslint_payload)
+pycodestyle = linter('pycodestyle', 5, read_pycodestyle_payload)
+pylint = linter('pylint', 5, read_pylint_payload)
 
 
 def assert_str_has(content: str, substrings: List[str]):


### PR DESCRIPTION
In some cases we may want to see more output than the default of 5 lines per error.