### PR TITLE
change prefix for build tag to be 999.0.0

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: PATH setup
         run: |
           echo "./packages/bash/lib" >> $GITHUB_PATH
-          pip install wemake-python-styleguide coverage mypy pylint build twine
+          pip3 install wemake-python-styleguide coverage mypy pylint build twine
       - name: Checks
         run: |
           ./m/scripts/checks/ci.sh

--- a/allowed_errors.json
+++ b/allowed_errors.json
@@ -1,5 +1,6 @@
 {
   "allowedFlake8Rules": {
+    "WPS473": 1,
     "B024": 1,
     "WPS359": 1,
     "WPS323": 1,

--- a/m/scripts/checks/Dockerfile
+++ b/m/scripts/checks/Dockerfile
@@ -1,5 +1,3 @@
-FROM python:3.8.7-alpine
+FROM python:3.8.14-bullseye
 
-RUN apk update && apk add bash
-
-RUN pip install pycodestyle pylint mypy pyyaml wemake-python-styleguide flake8 pyformat isort add-trailing-comma coverage bandit==1.7.2
+RUN pip install wemake-python-styleguide coverage mypy pylint build twine

--- a/packages/python/m/ci/git_env.py
+++ b/packages/python/m/ci/git_env.py
@@ -172,7 +172,7 @@ class GitEnv(JsonStr):
 def _build_tag_prefix(config: Config) -> str:
     if config.build_tag_with_version:
         return f'{config.version}-'
-    # TODO: Allow to set a specific build tag prefix
+    # Need to allow to set a specific build tag prefix
     return '999.0.0-'
 
 

--- a/packages/python/m/ci/git_env.py
+++ b/packages/python/m/ci/git_env.py
@@ -172,7 +172,8 @@ class GitEnv(JsonStr):
 def _build_tag_prefix(config: Config) -> str:
     if config.build_tag_with_version:
         return f'{config.version}-'
-    return '0.0.0-'
+    # TODO: Allow to set a specific build tag prefix
+    return '999.0.0-'
 
 
 def get_pr_number(branch: str) -> Optional[int]:

--- a/packages/python/tests/ci/release_env/test_git_flow.py
+++ b/packages/python/tests/ci/release_env/test_git_flow.py
@@ -88,7 +88,7 @@ class ReleaseEnvGitFlowTest(FpTestCase):
             self.assert_ok(result)
             self.assertEqual(
                 result.value.__dict__, dict(
-                    build_tag='0.0.0-master.b404',
+                    build_tag='999.0.0-master.b404',
                     is_release=False,
                     is_release_pr=False,
                     is_hotfix_pr=False,
@@ -110,7 +110,7 @@ class ReleaseEnvGitFlowTest(FpTestCase):
             self.assert_ok(result)
             self.assertEqual(
                 result.value.__dict__, dict(
-                    build_tag='0.0.0-pr1.b404',
+                    build_tag='999.0.0-pr1.b404',
                     is_release=False,
                     is_release_pr=False,
                     is_hotfix_pr=False,
@@ -240,7 +240,7 @@ class ReleaseEnvGitFlowTest(FpTestCase):
             self.assert_ok(result)
             self.assertEqual(
                 result.value.__dict__, dict(
-                    build_tag='0.0.0-develop.b404',
+                    build_tag='999.0.0-develop.b404',
                     is_release=False,
                     is_release_pr=False,
                     is_hotfix_pr=False,
@@ -374,7 +374,7 @@ class ReleaseEnvGitFlowTest(FpTestCase):
             self.assert_ok(result)
             self.assertEqual(
                 result.value.__dict__, dict(
-                    build_tag='0.0.0-develop.b404',
+                    build_tag='999.0.0-develop.b404',
                     is_release=False,
                     is_release_pr=False,
                     is_hotfix_pr=False,

--- a/packages/python/tests/ci/release_env/test_m_flow.py
+++ b/packages/python/tests/ci/release_env/test_m_flow.py
@@ -36,7 +36,7 @@ class ReleaseEnvMFlowTest(FpTestCase):
         result = self._get_env()
         self.assertFalse(result.is_bad)
         self.assertEqual(result.value.__dict__, dict(
-            build_tag='0.0.0-local.git-sha-abc-123',
+            build_tag='999.0.0-local.git-sha-abc-123',
             is_release=False,
             is_release_pr=False,
             is_hotfix_pr=False,
@@ -77,7 +77,7 @@ class ReleaseEnvMFlowTest(FpTestCase):
             result = self._get_env()
             self.assert_ok(result)
             self.assertEqual(result.value.__dict__, dict(
-                build_tag='0.0.0-master.b404',
+                build_tag='999.0.0-master.b404',
                 is_release=False,
                 is_release_pr=False,
                 is_hotfix_pr=False,
@@ -97,7 +97,7 @@ class ReleaseEnvMFlowTest(FpTestCase):
             result = self._get_env()
             self.assert_ok(result)
             self.assertEqual(result.value.__dict__, dict(
-                build_tag='0.0.0-pr1.b404',
+                build_tag='999.0.0-pr1.b404',
                 is_release=False,
                 is_release_pr=False,
                 is_hotfix_pr=False,


### PR DESCRIPTION
This is so that semver can accept pr builds as a higher pre-release version and thus no cause any conflict with tools such as npm.