### PR TITLE
support m.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+- `m init` creates `m.yaml`.
+- release tools handle `m.yaml` files as well as `m.json` files.
+
 ## [0.17.0] <a name="0.17.0" href="#0.17.0">-</a> March 14, 2023
 
 - Deprecate `reviewRelease`. Instead use `m review_release`.

--- a/packages/python/m/ci/config.py
+++ b/packages/python/m/ci/config.py
@@ -159,7 +159,15 @@ class Config(BaseModel):
         return issue(msg, context=err_data) if msg else Good(0)
 
 
-def _get_m_filename(m_dir: str) -> OneOf[Issue, str]:
+def get_m_filename(m_dir: str) -> OneOf[Issue, str]:
+    """Obtain the path to the m configuration file.
+
+    Args:
+        m_dir: The directory with the m configuration.
+
+    Returns:
+        The name of the configuration file or an issue if it doesn't exist.
+    """
     filenames = (f'{m_dir}/m.yaml', f'{m_dir}/m.yml', f'{m_dir}/m.json')
     for filename in filenames:
         if Path(filename).exists():
@@ -178,6 +186,6 @@ def read_config(m_dir: str) -> OneOf[Issue, Config]:
     """
     return one_of(lambda: [
         Config(m_dir=m_dir, **m_cfg)
-        for m_filename in _get_m_filename(m_dir)
+        for m_filename in get_m_filename(m_dir)
         for m_cfg in yaml_fp.read_yson(m_filename)
     ]).flat_map_bad(lambda x: issue('read_config failure', cause=x))

--- a/packages/python/m/ci/init.py
+++ b/packages/python/m/ci/init.py
@@ -43,7 +43,7 @@ def get_repo_info() -> OneOf[Issue, Tuple[str, str]]:
     ])
 
 
-def m_json_body(owner: str, repo: str) -> str:
+def m_config_body(owner: str, repo: str) -> str:
     """Create the basic contents of a m configuration file.
 
     Args:
@@ -51,15 +51,13 @@ def m_json_body(owner: str, repo: str) -> str:
         repo: The repo name.
 
     Returns:
-        A json string to be the content of the `m.json` file.
+        A yaml string to be the content of the `m.yaml` file.
     """
     body = f"""\
-        {{
-          "owner": "{owner}",
-          "repo": "{repo}",
-          "version": "0.0.0",
-          "workflow": "m_flow"
-        }}
+        owner: {owner}
+        repo: {repo}
+        version: 0.0.0
+        workflow: m_flow
     """
     return dedent(body)
 
@@ -70,7 +68,7 @@ def create_m_config() -> OneOf[Issue, str]:
     Returns:
         A `OneOf` containing 0 if successful or an `Issue`.
     """
-    file_name = 'm/m.json'
+    file_name = 'm/m.yaml'
     if Path.exists(Path(file_name)):
         logger.warning(f'{file_name} already exists')
         return Good(None)
@@ -80,7 +78,7 @@ def create_m_config() -> OneOf[Issue, str]:
     return one_of(lambda: [
         file_name
         for owner, repo in get_repo_info()
-        for _ in mio.write_file(file_name, m_json_body(owner, repo))
+        for _ in mio.write_file(file_name, m_config_body(owner, repo))
         for _ in logger.info(f'created {file_name}', {
             'owner': owner,
             'repo': repo,

--- a/packages/python/m/cli/commands/ci/release_setup.py
+++ b/packages/python/m/cli/commands/ci/release_setup.py
@@ -9,10 +9,6 @@ class Arguments(BaseModel):
         default='CHANGELOG.md',
         description='CHANGELOG filename',
     )
-    m_file: str = Field(
-        default='m.json',
-        description='m file name',
-    )
     m_dir: str = Field(
         description='m project directory',
         positional=True,
@@ -37,7 +33,6 @@ def run(arg: Arguments) -> int:
             arg.m_dir,
             None,
             arg.new_ver,
-            arg.m_file,
             arg.changelog,
         ),
     )

--- a/packages/python/tests/cli/commands/ci/env/test_env_gh.py
+++ b/packages/python/tests/cli/commands/ci/env/test_env_gh.py
@@ -56,7 +56,7 @@ class TCase(CliTestCase):
 def test_m_ci_env_gh(tcase: TCase, mocker: MockerFixture) -> None:
     # clear env vars to avoid ci tool specific messages
     mocker.patch.dict(os.environ, tcase.env_vars, clear=True)
-    mocker.patch('m.ci.config._get_m_filename').return_value = Good(
+    mocker.patch('m.ci.config.get_m_filename').return_value = Good(
         'm_dir_gh_m_flow/m.json',
     )
     mocker.patch('pathlib.Path.exists').return_value = True

--- a/packages/python/tests/cli/commands/ci/env/test_env_local.py
+++ b/packages/python/tests/cli/commands/ci/env/test_env_local.py
@@ -35,7 +35,7 @@ def test_m_ci_env_local(tcase: TCase, mocker: MockerFixture) -> None:
     # clear env vars to avoid ci tool specific messages
     mocker.patch.dict(os.environ, {}, clear=True)
     mocker.patch('pathlib.Path.exists').return_value = False
-    mocker.patch('m.ci.config._get_m_filename').return_value = Good(
+    mocker.patch('m.ci.config.get_m_filename').return_value = Good(
         'm_dir_local/m.json',
     )
     mocker.patch('pathlib.Path.mkdir')

--- a/packages/python/tests/cli/commands/ci/release_setup/fixtures/m.yaml
+++ b/packages/python/tests/cli/commands/ci/release_setup/fixtures/m.yaml
@@ -1,0 +1,3 @@
+owner: gh_owner
+repo: gh_repo
+version: 0.0.1

--- a/packages/python/tests/cli/commands/fixtures/m_fake.json
+++ b/packages/python/tests/cli/commands/fixtures/m_fake.json
@@ -1,6 +1,0 @@
-{
-  "owner": "fizzy",
-  "repo": "hotdog",
-  "version": "0.0.0",
-  "workflow": "m_flow"
-}

--- a/packages/python/tests/cli/commands/fixtures/m_fake.yaml
+++ b/packages/python/tests/cli/commands/fixtures/m_fake.yaml
@@ -1,0 +1,4 @@
+owner: fizzy
+repo: hotdog
+version: 0.0.0
+workflow: m_flow

--- a/packages/python/tests/cli/commands/fixtures/m_init_blank.log
+++ b/packages/python/tests/cli/commands/fixtures/m_init_blank.log
@@ -1,4 +1,4 @@
-[INFO] [09:33:09 PM - Nov 29, 1973]: created m/m.json
+[INFO] [09:33:09 PM - Nov 29, 1973]: created m/m.yaml
        {
          "owner": "jmlopez-rod",
          "repo": "m"
@@ -7,7 +7,7 @@
 [INFO] [09:33:09 PM - Nov 29, 1973]: setup complete
        {
          "modified_files": [
-           "m/m.json",
+           "m/m.yaml",
            "CHANGELOG.md"
          ]
        }

--- a/packages/python/tests/cli/commands/fixtures/m_init_blank_clog.log
+++ b/packages/python/tests/cli/commands/fixtures/m_init_blank_clog.log
@@ -1,4 +1,4 @@
-[INFO] [09:33:09 PM - Nov 29, 1973]: created m/m.json
+[INFO] [09:33:09 PM - Nov 29, 1973]: created m/m.yaml
        {
          "owner": "jmlopez-rod",
          "repo": "m"
@@ -6,6 +6,6 @@
 [INFO] [09:33:09 PM - Nov 29, 1973]: setup complete
        {
          "modified_files": [
-           "m/m.json"
+           "m/m.yaml"
          ]
        }

--- a/packages/python/tests/cli/commands/fixtures/m_init_blank_hotdog.log
+++ b/packages/python/tests/cli/commands/fixtures/m_init_blank_hotdog.log
@@ -1,4 +1,4 @@
-[INFO] [09:33:09 PM - Nov 29, 1973]: created m/m.json
+[INFO] [09:33:09 PM - Nov 29, 1973]: created m/m.yaml
        {
          "owner": "fizzy",
          "repo": "hotdog"
@@ -8,7 +8,7 @@
 [INFO] [09:33:09 PM - Nov 29, 1973]: setup complete
        {
          "modified_files": [
-           "m/m.json",
+           "m/m.yaml",
            ".gitignore",
            "CHANGELOG.md"
          ]

--- a/packages/python/tests/cli/commands/test_init.py
+++ b/packages/python/tests/cli/commands/test_init.py
@@ -25,7 +25,7 @@ class TCase(CliTestCase):
 
 def _file_exists(name: str, tcase: TCase):
     """Having issues using partial with file_exists_mock."""
-    if str(name) == 'm/m.json':
+    if str(name) == 'm/m.yaml':
         return tcase.m_file_exists
     if str(name) == 'CHANGELOG.md':
         return tcase.changelog_exists
@@ -69,7 +69,7 @@ def _eval_cmd(cmd: str, tcase: TCase):
         expected=read_fixture('m_init_repeat.log', FIXTURE_PATH),
         errors=[
             '[WARNING]',
-            'm/m.json already exists',
+            'm/m.yaml already exists',
         ],
         cleandoc=False,
         new_line=False,
@@ -82,7 +82,7 @@ def _eval_cmd(cmd: str, tcase: TCase):
         gitignore_contents='npm_modules\nhotdog',
         new_gitignore_contents='npm_modules\nhotdog\nm/.m\n',
         changelog='CHANGELOG.md',
-        m_file='m_fake.json',
+        m_file='m_fake.yaml',
     ),
 ])
 def test_m_init(tcase: TCase, mocker: MockerFixture) -> None:
@@ -124,7 +124,7 @@ def test_m_init(tcase: TCase, mocker: MockerFixture) -> None:
     m_call = all_calls[0]
     if tcase.m_file:
         assert m_call.args == (
-            'm/m.json',
+            'm/m.yaml',
             read_fixture(tcase.m_file, FIXTURE_PATH),
         )
 

--- a/packages/python/tests/run.sh
+++ b/packages/python/tests/run.sh
@@ -13,5 +13,5 @@ else
 # To run specific tests:
 # python -m unittest discover -s packages/python -v -k tests.cli.commands.test_json.CliJsonTest
 # python -m pytest -vv -k test_m_npm
-  pytest -p no:logging packages/python -vv -k test_m_review_release
+  pytest -p no:logging packages/python -vv -k test_m_ci_release_setup
 fi


### PR DESCRIPTION
- All tools handle `m.yaml`.
- Should be possible for projects to start using `m.yaml` instead of `m.json`.