### PR TITLE
fix circular import bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format of this changelog is based on
 
 ## [Unreleased]
 
+- Fix circular import bug. `python -c 'from m.core.io import env'` should not
+  fail.
+- Completions for the `m` cli [#86](https://github.com/jmlopez-rod/m/pull/86).
+
 ## [0.21.0] <a name="0.21.0" href="#0.21.0">-</a> April 27, 2023
 
 - The `build_tag_with_version` bumps the current version to the next minor

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@
 pip install jmlopez-m
 ```
 
+The cli supports `argcomplete`. To set it up follow the following depending on
+your shell
+
+```shell
+# for fish shell
+register-python-argcomplete --shell fish m > /tmp/foo
+sudo mv /tmp/foo /usr/share/fish/vendor_functions.d/m.fish
+
+# for bash shell
+register-python-argcomplete --shell bash m > /tmp/foo
+sudo mv /tmp/foo /usr/share/bash-completion/completions/m
+
+# for zsh
+register-python-argcomplete --shell zsh m > /tmp/foo
+sudo mv /tmp/foo /usr/share/zsh/site-functions/_m
+```
+
 ## development
 
 Start by opening the devcontainer in VSCode. Once there open a terminal and run

--- a/packages/python/m/log/ci_tools/ci_tools.py
+++ b/packages/python/m/log/ci_tools/ci_tools.py
@@ -1,4 +1,4 @@
-from m.core.io import env
+from m.core import io as mio
 
 from .providers.github import tool as gh_tool
 from .providers.local import tool as local_tool
@@ -13,6 +13,7 @@ def get_ci_tool() -> ProviderModule:
         A `ProviderModule` instance with methods to provide messages in
         a CI environment.
     """
+    env = mio.env
     if env('GITHUB_ACTIONS'):
         return gh_tool
     if env('TC') or env('TEAMCITY'):

--- a/packages/python/m/log/ci_tools/providers/github.py
+++ b/packages/python/m/log/ci_tools/providers/github.py
@@ -2,8 +2,9 @@ import logging
 from typing import cast
 
 from m.color import color
-from m.core import Issue, OneOf, issue, one_of
-from m.core.io import env_model
+from m.core import Issue, OneOf
+from m.core import io as mio
+from m.core import issue, one_of
 from m.log.misc import default_record_fmt, format_context, format_location
 from pydantic import BaseModel, Field
 
@@ -37,7 +38,7 @@ def env_vars() -> OneOf[Issue, EnvVars]:
                 server_url=server_url,
                 run_url=run_url,
             )
-            for env in env_model(GithubEnvVars)
+            for env in mio.env_model(GithubEnvVars)
             for run_url in (
                 f'{server_url}/{env.repo}/actions/runs/{env.run_id}',
             )

--- a/packages/python/m/log/config.py
+++ b/packages/python/m/log/config.py
@@ -1,6 +1,7 @@
 import logging
 
-from ..core.io import env
+from m.core import io as mio
+
 from .formatters import CiFormatter, JsonFormatter
 from .handlers import JsonFileHandler, StdErrHandler, StdOutHandler
 
@@ -20,7 +21,7 @@ def logging_config(level: int | None = None, json_file: str = '') -> None:
         json_formatter = JsonFormatter()
         all_handlers.append(JsonFileHandler(json_formatter, json_file))
 
-    debug_logs = env('DEBUG_M_LOGS', 'false') == 'true'
+    debug_logs = mio.env('DEBUG_M_LOGS', 'false') == 'true'
     default_level = logging.DEBUG if debug_logs else logging.INFO
     logging_level = level if level is not None else default_level
     logging.basicConfig(

--- a/packages/python/m/log/formatters.py
+++ b/packages/python/m/log/formatters.py
@@ -2,7 +2,7 @@ import json
 import logging
 import textwrap
 
-from m.core.io import is_python_info_enabled, is_traceback_enabled
+from m.core import io as mio
 
 from .ci_tools.ci_tools import get_ci_tool
 from .ci_tools.types import Message
@@ -59,8 +59,8 @@ class CiFormatter(logging.Formatter):
         super().__init__(datefmt=datefmt)
         self.opened_blocks: list[str] = []
         self.ci_tool = get_ci_tool()
-        self.show_traceback = is_traceback_enabled()
-        self.debug_python = is_python_info_enabled()
+        self.show_traceback = mio.is_traceback_enabled()
+        self.debug_python = mio.is_python_info_enabled()
 
     def format(self, record):
         """Format a record as based on the CI environment.


### PR DESCRIPTION
Found that that doing

```
python -c 'from m.core.io import env'
```

on the terminal would cause python to raise an exception.