### PR TITLE
test: auto-populate repo and owner by parsing origin url

### DIFF
--- a/packages/python/m/cli/cli.py
+++ b/packages/python/m/cli/cli.py
@@ -35,8 +35,10 @@ def _main_parser(
         formatter_class=raw,
         description=main_meta['description'] if main_meta else '...',
     )
+
     if add_args:
         add_args(argp)
+
     subp = argp.add_subparsers(
         title='commands',
         dest='command_name',
@@ -44,7 +46,9 @@ def _main_parser(
         help='additional help',
         metavar='<command>',
     )
+
     names = sorted(mod.keys())
+
     for name in names:
         if isinstance(mod[name], dict):
             meta_mod = meta[name]
@@ -74,6 +78,7 @@ def _main_parser(
             run_func = mod_inst.run
             if params_count(run_func) == 2:
                 run_func(None, subp)
+
     argcomplete.autocomplete(argp)
     return argp.parse_args()
 

--- a/packages/python/m/cli/commands/github/__init__.py
+++ b/packages/python/m/cli/commands/github/__init__.py
@@ -1,6 +1,8 @@
+import re
 from inspect import cleandoc
 
 from m.cli import cli_integration_token
+from m.cli.validators import validate_non_empty_str
 
 _DESC = """
     The following commands make calls to the Github api.
@@ -11,4 +13,49 @@ meta = {
     'description': cleandoc(_DESC),
 }
 
+def repo_and_owner():
+    """Return a function that takes in a parser.
+
+    This generated function registers a token argument in the parser
+    which looks for its value in the environment variables.
+
+    Args:
+        integration: The name of the integration.
+        env_var: The environment variable name.
+
+    Returns:
+        A function to add arguments to an argparse parser.
+    """
+    from m.git import get_remote_url
+    repository_url = get_remote_url()
+    print(repository_url.value)
+
+    if repository_url.is_bad:
+        return lambda parser: parser
+
+    repository_url_parser = re.compile(r"((?:https?:\/\/)|(?:\w+@))github\.com[:\/]([^\/]+)\/([^\/]+)\.git")
+
+    match = repository_url_parser.match(repository_url.value)
+
+    if match is None:
+        return lambda parser: parser
+
+    _, owner, repo = match.groups()
+
+    def extend_parser(parser):
+        parser.add_argument(
+            '--owner',
+            default=owner,
+            required=False,
+        )
+        parser.add_argument(
+            '--repo',
+            default=repo,
+            required=False,
+        )
+
+    return extend_parser
+
+
 add_arguments = cli_integration_token('github', 'GITHUB_TOKEN')
+

--- a/packages/python/m/cli/commands/github/branch_prs.py
+++ b/packages/python/m/cli/commands/github/branch_prs.py
@@ -1,10 +1,10 @@
 from m.cli import command, run_main
 from m.cli.handlers import create_dict_handler
-from m.core.io import env
+from m.github.argumets import RepoAndOwnerArgs
 from pydantic import BaseModel, Field
 
 
-class Arguments(BaseModel):
+class Arguments(RepoAndOwnerArgs):
     """Retrieve pull requests associated with a branch.
 
     example::
@@ -19,14 +19,6 @@ class Arguments(BaseModel):
     yaml: bool = Field(
         default=False,
         description='use yaml format',
-    )
-    owner: str = Field(
-        default=env('GITHUB_REPOSITORY_OWNER'),
-        description='repo owner',
-    )
-    repo: str = Field(
-        description='repo name',
-        required=True,
     )
     branch: str = Field(
         description='branch name',

--- a/packages/python/m/github/argumets.py
+++ b/packages/python/m/github/argumets.py
@@ -1,0 +1,34 @@
+import re
+
+from m.git import get_remote_url
+from pydantic import BaseModel, Field
+
+
+def repo_and_owner():
+    repository_url = get_remote_url()
+
+    if repository_url.is_bad:
+        return None, None
+
+    repository_url_parser = re.compile(r"((?:https?:\/\/)|(?:\w+@))github\.com[:\/]([^\/]+)\/([^\/]+)\.git")
+
+    match = repository_url_parser.match(repository_url.value)
+
+    if match is None:
+        return None, None
+
+    _, owner, repo = match.groups()
+
+    return owner, repo
+
+owner, repo = repo_and_owner()
+
+class RepoAndOwnerArgs(BaseModel):
+    owner: str = Field(
+        default=owner,
+        description='repo owner',
+    )
+    repo: str = Field(
+        default=repo,
+        description='repo name',
+    )


### PR DESCRIPTION
This is a test of a feature that auto populates the defaults for repo/owner args in `github` commands.

This makes it easier to use `github` commands.

-----

Hope you are having a great day man.