### PR TITLE
git tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format of this changelog is based on
 
 ## [Unreleased]
 
+- Add `m git tag_release`. This command allows us to tag a release. It is meant
+  to be used after `m github release` to create git tags that keep track of the
+  major and minor versions of a project. It assumes that the version provided is
+  a valid semver of the form `x.y.z`.
+
 ## [0.26.0] <a name="0.26.0" href="#0.26.0">-</a> September 09, 2023
 
 - Add `--section` to `m devcontainer bashrc` so that we may specify a bashrc

--- a/m/scripts/publish.sh
+++ b/m/scripts/publish.sh
@@ -14,3 +14,6 @@ python3 -m twine upload .stage-pypi/dist/*
 
 # Let github know we released
 m github release --owner jmlopez-rod --repo m --version "$M_TAG"
+
+# Create v tags
+m git tag_release --version "$M_TAG"

--- a/packages/python/m/cli/commands/git/tag_release.py
+++ b/packages/python/m/cli/commands/git/tag_release.py
@@ -1,0 +1,44 @@
+from m.cli import Arg, BaseModel, command, run_main
+
+
+class Arguments(BaseModel):
+    """Supplement to `m github release`.
+
+    This command needs the `git` cli and it is meant to be run after
+    `m github release` to create a major and minor release tags.
+
+
+    example::
+
+        $ m git tag_release --version 1.2.3
+
+
+    It will create or update the following tags::
+
+        -v1
+        -v1.2
+
+    Note that the tags may be moved with each release to point to the latest
+    release. This is done by deleting the tag and creating it again.
+    """
+
+    version: str = Arg(
+        help='version to create tags from',
+        required=True,
+    )
+    sha: str = Arg(
+        default='',
+        help='sha to tag',
+    )
+
+
+@command(
+    help='tag github releases',
+    model=Arguments,
+)
+def run(arg: Arguments) -> int:
+    from m import git
+    return run_main(
+        lambda: git.tag_release(arg.version, arg.sha),
+        result_handler=print,
+    )

--- a/packages/python/m/git.py
+++ b/packages/python/m/git.py
@@ -1,4 +1,4 @@
-from m.core import Good, Res, hone, one_of, subprocess
+from m.core import Bad, Good, Res, hone, one_of, subprocess
 
 
 def get_branch() -> Res[str]:
@@ -187,3 +187,71 @@ def raw_status() -> Res[str]:
         A `OneOf` containing an `Issue` or the output of "git status".
     """
     return subprocess.eval_cmd('git status')
+
+
+def _list_tags(tag_response: str) -> dict[str, str]:
+    lines = tag_response.strip().splitlines()
+    split_lines = (line.split('\trefs/tags/') for line in lines)
+    return {tag: sha for sha, tag in split_lines}
+
+
+def list_tags(pattern: str) -> Res[dict[str, str]]:
+    """List all the tags matching a pattern.
+
+    Args:
+        pattern: The pattern to match.
+
+    Returns:
+        A `OneOf` containing an `Issue` or a string specifying the branch.
+    """
+    cmd = f'git ls-remote --tags origin -l "{pattern}"'
+    return one_of(
+        lambda: [
+            _list_tags(output)
+            for output in subprocess.eval_cmd(cmd)
+        ],
+    )
+
+
+def remove_git_tag(tag) -> Res[str]:
+    """Remove a git tag.
+
+    Args:
+        tag: The tag to remove.
+
+    Returns:
+        A `OneOf` containing an `Issue` or the response from the git command.
+    """
+    return one_of(lambda: [
+        f'{local}\n{remote}'
+        for local in subprocess.eval_cmd(f'git tag -d {tag}')
+        for remote in subprocess.eval_cmd(f'git push origin :refs/tags/{tag}')
+    ])
+
+
+def update_git_tag(tag: str, sha: str, remote_tags: list[str]) -> Res[str]:
+    """Create or move a git tag.
+
+    The remote_tags should be provided to determine if we need to remove them
+    before moving the tag. See https://stackoverflow.com/a/28280404 for more
+    details on the git commands.
+
+    Args:
+        tag: The tag to set.
+        sha: The commit sha to set the tag to.
+        remote_tags: The list of remote tags.
+
+    Returns:
+        A `OneOf` containing an `Issue` or the response from the git command.
+    """
+    removal_output = ''
+    if tag in remote_tags:
+        removal_res = remove_git_tag(tag)
+        if isinstance(removal_res, Bad):
+            return Bad(removal_res.value)
+        removal_output = f'{removal_res.value}\n'
+    return one_of(lambda: [
+        f'{removal_output}{local}\n{remote}'
+        for local in subprocess.eval_cmd(f'git tag {tag} {sha}')
+        for remote in subprocess.eval_cmd(f'git push origin {tag}')
+    ])

--- a/packages/python/tests/cli/commands/test_git.py
+++ b/packages/python/tests/cli/commands/test_git.py
@@ -60,6 +60,22 @@ from m import git
         ],
         expected='ahead',
     ),
+    TCase(
+        cmd='m git tag_release --version 1.2.3',
+        eval_cmd_side_effects=[
+            Good(''),
+            Good('local create - major'),
+            Good('remote create - major'),
+            Good('local create - minor'),
+            Good('remote create - minor'),
+        ],
+        expected='\n'.join([
+            'local create - major',
+            'remote create - major',
+            'local create - minor',
+            'remote create - minor',
+        ]),
+    ),
 ])
 def test_m_git_cli(tcase: TCase, mocker: MockerFixture) -> None:
     eval_cmd = mocker.patch('m.core.subprocess.eval_cmd')

--- a/packages/python/tests/cli/commands/test_git.py
+++ b/packages/python/tests/cli/commands/test_git.py
@@ -1,5 +1,5 @@
 import pytest
-from m.core import Good, issue
+from m.core import Bad, Good, issue
 from pytest_mock import MockerFixture
 from tests.cli.conftest import TCase, assert_streams, run_cli
 
@@ -122,6 +122,46 @@ def test_m_git_cli(tcase: TCase, mocker: MockerFixture) -> None:
         cmd='...',
         eval_cmd_side_effects=[Good('created commit')],
         expected='created commit',
+    ),
+    TCase(
+        runner=lambda: git.list_tags('0*'),
+        cmd='...',
+        eval_cmd_side_effects=[
+            Good('sha1\trefs/tags/0.7.0\nsha2\trefs/tags/0.7.1\n\n'),
+        ],
+        expected_value={
+            '0.7.0': 'sha1',
+            '0.7.1': 'sha2',
+        },
+    ),
+    TCase(
+        runner=lambda: git.update_git_tag('v1.2', 'sha1', ['v1.2', 'v1.3']),
+        cmd='...',
+        eval_cmd_side_effects=[
+            Good('local delete'),
+            Good('remote delete'),
+            Good('local create'),
+            Good('remote create'),
+        ],
+        expected='local delete\nremote delete\nlocal create\nremote create',
+    ),
+    TCase(
+        runner=lambda: git.update_git_tag('v1.2', 'sha1', ['v1.3']),
+        cmd='...',
+        eval_cmd_side_effects=[
+            Good('local create'),
+            Good('remote create'),
+        ],
+        expected='local create\nremote create',
+    ),
+    TCase(
+        runner=lambda: git.update_git_tag('v1.2', 'sha1', ['v1.2']),
+        cmd='...',
+        eval_cmd_side_effects=[
+            Good('local remove'),
+            Bad('oops, cannot delete tag'),
+        ],
+        expected='oops, cannot delete tag',
     ),
 ])
 def test_m_git_fns(tcase: TCase, mocker: MockerFixture) -> None:

--- a/packages/python/tests/run.sh
+++ b/packages/python/tests/run.sh
@@ -13,7 +13,7 @@ else
 # To run specific tests:
 # python -m unittest discover -s packages/python -v -k tests.cli.commands.test_json.CliJsonTest
 # python -m pytest -vv -k test_m_npm
-  pytest -p no:logging packages/python -vv -k test_m_git_fns
+  pytest -p no:logging packages/python -vv -k test_m_git_cli
 fi
 
 mkdir -p m/.m

--- a/packages/python/tests/run.sh
+++ b/packages/python/tests/run.sh
@@ -13,7 +13,7 @@ else
 # To run specific tests:
 # python -m unittest discover -s packages/python -v -k tests.cli.commands.test_json.CliJsonTest
 # python -m pytest -vv -k test_m_npm
-  pytest -p no:logging packages/python -vv -k test_bashrc
+  pytest -p no:logging packages/python -vv -k test_m_git_fns
 fi
 
 mkdir -p m/.m


### PR DESCRIPTION
Similarly to how github actions tag their releases we can now keep track of the major versions or releases as well as the current minor version.