### PR TITLE
track major version only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format of this changelog is based on
 
 ## [Unreleased]
 
+- Add `--major-only` option to `m git tag_release`. This option allows us to
+  only update the major version tag.
+- This project is switching to only moving the `major` tag and drops the minor
+  version tag.
+
 ## [0.27.3] <a name="0.27.3" href="#0.27.3">-</a> September 13, 2023
 
 - Typo on code. I hope this is the last hotfix for `m git tag_release`.

--- a/m/scripts/publish.sh
+++ b/m/scripts/publish.sh
@@ -16,4 +16,4 @@ python3 -m twine upload .stage-pypi/dist/*
 m github release --owner jmlopez-rod --repo m --version "$M_TAG"
 
 # Create v tags
-m git tag_release --version "$M_TAG"
+m git tag_release --version "$M_TAG" --major-only

--- a/packages/python/m/cli/commands/git/tag_release.py
+++ b/packages/python/m/cli/commands/git/tag_release.py
@@ -30,6 +30,10 @@ class Arguments(BaseModel):
         default='',
         help='sha to tag',
     )
+    major_only: bool = Arg(
+        default=False,
+        help='only create major tag',
+    )
 
 
 @command(
@@ -39,6 +43,6 @@ class Arguments(BaseModel):
 def run(arg: Arguments) -> int:
     from m import git
     return run_main(
-        lambda: git.tag_release(arg.version, arg.sha),
+        lambda: git.tag_release(arg.version, arg.sha, major_only=arg.major_only),
         result_handler=print,
     )

--- a/packages/python/tests/cli/commands/test_git.py
+++ b/packages/python/tests/cli/commands/test_git.py
@@ -76,6 +76,19 @@ from m import git
             'remote create - minor',
         ]),
     ),
+    TCase(
+        cmd='m git tag_release --version 1.2.3 --major-only',
+        eval_cmd_side_effects=[
+            Good(''),
+            Good('local create - major'),
+            Good('remote create - major'),
+        ],
+        expected='\n'.join([
+            'local create - major',
+            'remote create - major',
+            'skipping v1.2',
+        ]),
+    ),
 ])
 def test_m_git_cli(tcase: TCase, mocker: MockerFixture) -> None:
     eval_cmd = mocker.patch('m.core.subprocess.eval_cmd')


### PR DESCRIPTION
some projects may only need to keep track of the major version tag. (github actions). Lets add this flag to only create and update the major version tag.