### PR TITLE
regexps

### DIFF
--- a/packages/python/m/ci/types.py
+++ b/packages/python/m/ci/types.py
@@ -10,7 +10,7 @@ class Branches(str, Enum):  # noqa: WPS600
 
     master = 'master'
     develop = 'develop'
-    release = 'release'
+    release = '"release/\d+\.\d+\.\d+"'
     hotfix = 'hotfix'
 
     def __str__(self: 'Branches') -> str:

--- a/packages/python/m/github/ci_dataclasses.py
+++ b/packages/python/m/github/ci_dataclasses.py
@@ -60,7 +60,8 @@ class Commit(BaseModel):
         """
         if not release_prefix:
             return False
-        return self.get_pr_branch().startswith(release_prefix)
+        return re.search(release_prefix, self.get_pr_branch) is not None
+
 
 
 class PullRequest(BaseModel):
@@ -90,8 +91,7 @@ class PullRequest(BaseModel):
         """
         if not release_prefix:
             return False
-        release_regexp = "release/\d+\.\d+\.\d+"
-        return re.search(release_regexp, self.pr_branch) is not None
+        return re.search(release_prefix, self.pr_branch) is not None
 
 
 class Release(BaseModel):

--- a/packages/python/m/github/ci_dataclasses.py
+++ b/packages/python/m/github/ci_dataclasses.py
@@ -1,3 +1,4 @@
+import re
 from typing import List, Optional
 
 from m.pydantic import CamelModel
@@ -89,7 +90,8 @@ class PullRequest(BaseModel):
         """
         if not release_prefix:
             return False
-        return self.pr_branch.startswith(release_prefix)
+        release_regexp = "release/\d+\.\d+\.\d+"
+        return re.search(release_regexp, self.pr_branch) is not None
 
 
 class Release(BaseModel):

--- a/packages/python/tests/github/test_ci_dataclasses.py
+++ b/packages/python/tests/github/test_ci_dataclasses.py
@@ -60,7 +60,7 @@ class CiDataclassesTest(FpTestCase):
         associated_pr.pr_branch = 'some-feature'
         self.assertFalse(commit.is_release(release_prefix))
         # Release
-        associated_pr.pr_branch = 'release'
+        associated_pr.pr_branch = 'release/1.2.3'
         self.assertTrue(commit.is_release(release_prefix))
 
     def test_pr_is_release_pr(self) -> None:
@@ -69,7 +69,7 @@ class CiDataclassesTest(FpTestCase):
         self.assertFalse(pr.is_release_pr(None))
         # Not a release pr due to branches not matching
         release_prefix = 'release'
-        pr.pr_branch = 'some-feature'
+        pr.pr_branch = 'release'
         self.assertFalse(pr.is_release_pr(release_prefix))
         # Release PR
         pr.pr_branch = 'release/1.2.3'

--- a/packages/python/tests/github/test_ci_dataclasses.py
+++ b/packages/python/tests/github/test_ci_dataclasses.py
@@ -72,5 +72,5 @@ class CiDataclassesTest(FpTestCase):
         pr.pr_branch = 'some-feature'
         self.assertFalse(pr.is_release_pr(release_prefix))
         # Release PR
-        pr.pr_branch = 'release'
+        pr.pr_branch = 'release/1.2.3'
         self.assertTrue(pr.is_release_pr(release_prefix))


### PR DESCRIPTION
check that a branch is in the form of `release/x.y.z` instead of 'release' to identify something as a release branch :crab: 