### PR TITLE
require changelog in PRs

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Install
         run: |
-          env
           python3 -m venv /opt/venv/m
           poetry install
 

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Install
         run: |
+          env
           python3 -m venv /opt/venv/m
           poetry install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format of this changelog is based on
   https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/
   Defaults to `false`. In the future it may be set to `true` by default or
   removed completely if the buildx command replaces the old way.
+- The `m ci env` command will fail if pull requests do not modify the
+  `CHANGELOG.md` file. This is to ensure that we are keeping track of the
+  changes that are being made to the project. If we need to bypass it we can set
+  `require_pr_changelog` to `false` in the `m` configuration.
 
 ## [0.32.1] <a name="0.32.1" href="#0.32.1">-</a> March 17, 2024
 

--- a/packages/python/m/ci/config.py
+++ b/packages/python/m/ci/config.py
@@ -33,6 +33,10 @@ class Config(BaseModel):
     repo: str
     version: str = '0.0.0'
     workflow: Workflow = Workflow.free_flow
+
+    # If true it will require an update to the changelog for every PR.
+    require_pr_changelog: bool = True
+
     git_flow: GitFlowConfig = GitFlowConfig(
         master_branch=Branches.master,
         develop_branch=Branches.develop,

--- a/packages/python/m/ci/git_env.py
+++ b/packages/python/m/ci/git_env.py
@@ -271,7 +271,7 @@ def get_git_env(config: Config, env_vars: EnvVars) -> Res[GitEnv]:
             sha=env_vars.git_sha,
         ),
         pr_number=pr_number,
-        file_count=0,
+        file_count=100,
         include_release=True,
     )
     if isinstance(git_env_box, Bad):
@@ -281,7 +281,10 @@ def get_git_env(config: Config, env_vars: EnvVars) -> Res[GitEnv]:
     pr = res.pull_request
 
     if pr and config.require_pr_changelog and not pr.changelog_updated():
-        return issue('missing CHANGELOG.md in PR', context={'pr': pr.model_dump()})
+        # If this is a huge PR we'll bypass it, the file may not be present in
+        # the list of files.
+        if pr.file_count < 100:
+            return issue('missing CHANGELOG.md in PR', context={'pr': pr.model_dump()})
 
     git_env.sha = res.commit.sha
     git_env.target_branch = pr.target_branch if pr else branch

--- a/packages/python/m/ci/git_env.py
+++ b/packages/python/m/ci/git_env.py
@@ -279,6 +279,10 @@ def get_git_env(config: Config, env_vars: EnvVars) -> Res[GitEnv]:
 
     res = git_env_box.value
     pr = res.pull_request
+
+    if pr and config.require_pr_changelog and not pr.changelog_updated():
+        return issue('missing CHANGELOG.md in PR', context={'pr': pr.model_dump()})
+
     git_env.sha = res.commit.sha
     git_env.target_branch = pr.target_branch if pr else branch
     git_env.commit = res.commit

--- a/packages/python/m/github/ci.py
+++ b/packages/python/m/github/ci.py
@@ -197,9 +197,11 @@ def _get_pull_request(
     pr_number: Optional[int],
 ) -> OneOf[Issue, Optional[PullRequest]]:
     pr = raw.get('pullRequest')
+    print('PR', pr)
     if not pr:
         return Good(None)
     author = pr.get('author', {})
+    pr_files = pr.get('files', {})
     return Good(
         PullRequest(
             author=Author(**author),
@@ -210,8 +212,8 @@ def _get_pull_request(
             url=pr.get('url'),
             title=pr.get('title'),
             body=pr.get('body'),
-            file_count=pr.get('files', {}).get('totalCount', 0),
-            files=[x['path'] for x in pr.get('files', {}).get('nodes', [])],
+            file_count=pr_files.get('totalCount', 0),
+            files=[x['path'] for x in pr_files.get('nodes', [])],
             is_draft=pr.get('isDraft'),
         ),
     )

--- a/packages/python/m/github/ci.py
+++ b/packages/python/m/github/ci.py
@@ -197,7 +197,6 @@ def _get_pull_request(
     pr_number: Optional[int],
 ) -> OneOf[Issue, Optional[PullRequest]]:
     pr = raw.get('pullRequest')
-    print('PR', pr)
     if not pr:
         return Good(None)
     author = pr.get('author', {})
@@ -245,7 +244,6 @@ def get_ci_run_info(
         file_count,
         include_release,
     )
-    print('RAW_RES:', raw_res)
     return one_of(
         lambda: [
             GithubCiRunInfo(commit=commit, pull_request=pr, release=release)

--- a/packages/python/m/github/ci.py
+++ b/packages/python/m/github/ci.py
@@ -245,6 +245,7 @@ def get_ci_run_info(
         file_count,
         include_release,
     )
+    print('RAW_RES:', raw_res)
     return one_of(
         lambda: [
             GithubCiRunInfo(commit=commit, pull_request=pr, release=release)

--- a/packages/python/m/github/ci_dataclasses.py
+++ b/packages/python/m/github/ci_dataclasses.py
@@ -65,7 +65,6 @@ class Commit(BaseModel):
 class PullRequest(BaseModel):
     """Pull request information."""
 
-    # pylint: disable=too-many-instance-attributes
     author: Author
     pr_number: int
     pr_branch: str
@@ -77,6 +76,14 @@ class PullRequest(BaseModel):
     file_count: int
     files: List[str]
     is_draft: bool
+
+    def changelog_updated(self) -> bool:
+        """Determine if the changelog was updated in the pull request.
+
+        Returns:
+            True if the changelog was updated.
+        """
+        return 'CHANGELOG.md' in self.files
 
     def is_release_pr(self, release_prefix: str | None) -> bool:
         """Determine if the pull request is a release pull request.

--- a/packages/python/m/github/ci_graph_queries.py
+++ b/packages/python/m/github/ci_graph_queries.py
@@ -39,12 +39,6 @@ def commit_query(include_pr: bool, include_author: bool) -> str:
           headRefName
           headRefOid
           merged
-          files(first: $fc) {
-            totalCount
-            nodes {
-              path
-            }
-          }
         }
       }
     """ if include_pr else ''

--- a/packages/python/m/github/ci_graph_queries.py
+++ b/packages/python/m/github/ci_graph_queries.py
@@ -39,6 +39,12 @@ def commit_query(include_pr: bool, include_author: bool) -> str:
           headRefName
           headRefOid
           merged
+          files(first: $fc) {
+            totalCount
+            nodes {
+              path
+            }
+          }
         }
       }
     """ if include_pr else ''

--- a/packages/python/tests/ci/fixtures/pr1-no-changelog.json
+++ b/packages/python/tests/ci/fixtures/pr1-no-changelog.json
@@ -14,6 +14,7 @@
         "message": "using head commit\n\nhttps://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit",
         "author": {
           "name": "Manuel Lopez",
+          "email": "",
           "user": {
             "login": "jmlopez-rod"
           }
@@ -30,19 +31,17 @@
         "url": "https://github.com/jmlopez-rod/gh-actions/pull/1",
         "author": {
           "login": "jmlopez-rod",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/1810397?s=50&v=4"
+          "avatarUrl": "https://avatars.githubusercontent.com/u/1810397?s=50&v=4",
+          "email": ""
         },
         "files": {
-          "totalCount": 3,
+          "totalCount": 2,
           "nodes": [
             {
               "path": ".github/workflows/build.yml"
             },
             {
               "path": "new.txt"
-            },
-            {
-              "path": "CHANGELOG.md"
             }
           ]
         },

--- a/packages/python/tests/ci/fixtures/pr1.json
+++ b/packages/python/tests/ci/fixtures/pr1.json
@@ -35,13 +35,16 @@
           "email": ""
         },
         "files": {
-          "totalCount": 2,
+          "totalCount": 3,
           "nodes": [
             {
               "path": ".github/workflows/build.yml"
             },
             {
               "path": "new.txt"
+            },
+            {
+              "path": "CHANGELOG.md"
             }
           ]
         },

--- a/packages/python/tests/ci/release_env/test_m_flow.py
+++ b/packages/python/tests/ci/release_env/test_m_flow.py
@@ -48,6 +48,27 @@ from .util import CONFIG, ENV_VARS, TCase, mock_commit_sha
         ),
     ),
     TCase(
+        desc='pr 1 - no changelog',
+        config={'version': '1.1.1'},
+        env_vars={'git_branch': 'refs/pull/1'},
+        gh_res='pr1-no-changelog.json',
+        err='missing CHANGELOG.md in PR',
+    ),
+    TCase(
+        desc='pr 1 - no changelog bypass',
+        config={'version': '1.1.1', 'require_pr_changelog': False},
+        env_vars={'git_branch': 'refs/pull/1'},
+        gh_res='pr1-no-changelog.json',
+        release_env=ReleaseEnv(
+            build_tag='0.0.0-pr1.b404',
+            python_tag='0.0.0b1.dev404',
+            is_release=False,
+            is_release_pr=False,
+            is_hotfix_pr=False,
+            workflow=Workflow.m_flow,
+        ),
+    ),
+    TCase(
         desc='pr 1 - dev versioning',
         config={'version': '1.1.1', 'build_tag_with_version': True},
         env_vars={'git_branch': 'refs/pull/1'},

--- a/packages/python/tests/run.sh
+++ b/packages/python/tests/run.sh
@@ -17,7 +17,7 @@ if [ "$SINGLE" = 'false' ]; then
 else
   # To run specific tests:
   source="packages/python/m/github/actions"
-  filter="test_blueprints"
+  filter="test_m_flow"
   coverage run --source "$source" -m pytest -p no:logging packages/python -vv -k "$filter"
   coverage report -m
 fi


### PR DESCRIPTION
I always forget to fill out the changelog so this forced feature should help with it. If we need to disable it we can always add `require_pr_changelog` in the `m` configuration.

As a quick test the first build should fail.